### PR TITLE
add --no-check-certificate to wget

### DIFF
--- a/scripts/sharedFuncs.sh
+++ b/scripts/sharedFuncs.sh
@@ -197,7 +197,7 @@ function download_component() {
                 curl $3 -o $1
             else
                 show_message "using wget to download $4"
-                wget "$3" -P "$CACHE_PATH"
+                wget --no-check-certificate "$3" -P "$CACHE_PATH"
                 
                 if [ $? -eq 0 ];then
                     notify-send "Photoshop CC" "$4 download completed" -i "download"


### PR DESCRIPTION
the instalation was failed due to the web that hosted photoshop has an expired certificate, producing an error.

added the wget --no-check-certificate and the installer was up and running again.

btw, this happen to the illustrator one too. i'll try to take a look if i can