### PR TITLE
Disable curl certificate checking to avoid error

### DIFF
--- a/scripts/sharedFuncs.sh
+++ b/scripts/sharedFuncs.sh
@@ -194,7 +194,7 @@ function download_component() {
 
             elif [ "$curlpkg" == "true" ];then
                 show_message "using curl to download $4"
-                curl $3 -o $1
+                curl -k $3 -o $1
             else
                 show_message "using wget to download $4"
                 wget --no-check-certificate "$3" -P "$CACHE_PATH"


### PR DESCRIPTION
Avoid the `curl failed to verify the legitimacy of the server and therefore could not establish a secure connection to it` error by adding the -k flag to curl.