### PR TITLE
Allow continue on download retries

### DIFF
--- a/scripts/sharedFuncs.sh
+++ b/scripts/sharedFuncs.sh
@@ -183,6 +183,7 @@ function download_component() {
             show_message "downloading $4 ..."
             ariapkg=$(package_installed aria2c "summary")
             curlpkg=$(package_installed curl "summary")
+            wgetpkg=$(package_installed wget "summary")
             
             if [ "$ariapkg" == "true" ];then
                 show_message "using aria2c to download $4"
@@ -192,12 +193,12 @@ function download_component() {
                     notify-send "Photoshop CC" "$4 download completed" -i "download"
                 fi
 
-            elif [ "$curlpkg" == "true" ];then
-                show_message "using curl to download $4"
-                curl $3 -o $1
-            else
+            elif [ "$wgetpkg" == "true" ];then
                 show_message "using wget to download $4"
-                wget --no-check-certificate "$3" -P "$CACHE_PATH"
+                wget --no-check-certificate "$3" --continue --tries=0 -P "$CACHE_PATH"
+            else
+                show_message "using curl to download $4"
+                curl $3 --retry 999 --retry-all-errors -C - -o $1
                 
                 if [ $? -eq 0 ];then
                     notify-send "Photoshop CC" "$4 download completed" -i "download"


### PR DESCRIPTION
This patch tries to resolve https://github.com/Gictorbit/photoshopCClinux/issues/175 , https://github.com/Gictorbit/photoshopCClinux/issues/167 , https://github.com/Gictorbit/photoshopCClinux/issues/150 (and alikes if they exist). The server (victor.poshtiban.io) drops connection(?) every 200Mb or so, making curl to fail with "HTTP/2 stream 0 was not closed cleanly: INTERNAL_ERROR (err 2)". 

Existing suggestions either need custom [script](https://github.com/Gictorbit/photoshopCClinux/issues/150#issuecomment-1075448907),  or at least require the user to [download and move the file](https://github.com/Gictorbit/photoshopCClinux/issues/175#issuecomment-1158960855). It seems unnecessary. I propose to retry & continue in-place with `wget`, which should be available on most linux systems.

The `curl` command was also modified to allow retry and continue, but it won't go through that particular error. I'm not familiar with curl, sorry. I think it should be able to, but can't find the right solution.